### PR TITLE
classpath问题导致启动找不到配置文件

### DIFF
--- a/proxy-client/src/main/resources/startup.sh
+++ b/proxy-client/src/main/resources/startup.sh
@@ -21,7 +21,7 @@ STDOUT_FILE=$LOGS_DIR/stdout.log
 CLOG_FILE=$LOGS_DIR/gc.log
 
 LIB_DIR=$DEPLOY_DIR/lib
-LIB_JARS=`ls $LIB_DIR|grep .jar|awk '{print "'$LIB_DIR'/"$0}'|tr "\n" ":"`
+LIB_JARS=`ls $LIB_DIR|grep .jar|awk '{print "'$LIB_DIR'/"$0}'| xargs | sed "s/ /:/g"`
 
 JAVA_OPTS=" -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true "
 JAVA_DEBUG_OPTS=""

--- a/proxy-server/src/main/resources/startup.sh
+++ b/proxy-server/src/main/resources/startup.sh
@@ -21,7 +21,7 @@ STDOUT_FILE=$LOGS_DIR/stdout.log
 CLOG_FILE=$LOGS_DIR/gc.log
 
 LIB_DIR=$DEPLOY_DIR/lib
-LIB_JARS=`ls $LIB_DIR|grep .jar|awk '{print "'$LIB_DIR'/"$0}'|tr "\n" ":"`
+LIB_JARS=`ls $LIB_DIR|grep .jar|awk '{print "'$LIB_DIR'/"$0}'| xargs | sed "s/ /:/g"`
 
 JAVA_OPTS=" -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true "
 JAVA_DEBUG_OPTS=""


### PR DESCRIPTION
classpath末尾多一个冒号(:)导致启动时找不到配置文件，启动失败