### PR TITLE
fix(sec): upgrade io.netty:netty-all to 4.1.44.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.0.36.Final</version>
+            <version>4.1.44.Final</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-all 4.0.36.Final
- [CVE-2019-16869](https://www.oscs1024.com/hd/CVE-2019-16869)


### What did I do？
Upgrade io.netty:netty-all from 4.0.36.Final to 4.1.44.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS